### PR TITLE
Update nova require version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": "3.0.*"
+        "laravel/nova": "3.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I tried to require this package but version `3.0.*` doesn't work

```
Problem 1
    - Installation request for chris-ware/nova-breadcrumbs dev-master -> satisfiable by chris-ware/nova-breadcrumbs[dev-master].
    - chris-ware/nova-breadcrumbs dev-master requires laravel/nova 3.0.* -> no matching package found.
```

```bash
composer info laravel/nova
```
```
name     : laravel/nova
descrip. : A wonderful administration interface for Laravel.
keywords : admin, laravel
versions : * dev-master, 3.x-dev
```