### PR TITLE
bugfix - allow use of the overwritten label

### DIFF
--- a/src/Traits/Breadcrumbs.php
+++ b/src/Traits/Breadcrumbs.php
@@ -30,7 +30,7 @@ trait Breadcrumbs
 
     public static function breadcrumbResourceLabel()
     {
-        return self::label();
+        return static::label();
     }
 
     public function breadcrumbResourceTitle()


### PR DESCRIPTION
## What

Currently it does not support overriding the labels - which is a core feature of Laravel Nova.

This PR fixes that.

![image](https://user-images.githubusercontent.com/312003/93065323-d9466880-f678-11ea-9475-18e153b562b2.png)

instead of

![image](https://user-images.githubusercontent.com/312003/93065365-eb280b80-f678-11ea-85bf-aaf01277cc3c.png)
