### PR TITLE
Ignore everything after question mark in url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "chris-ware/nova-breadcrumbs",
+    "name": "fathur/nova-breadcrumbs",
     "description": "A Laravel Nova tool.",
     "keywords": [
         "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "fathur/nova-breadcrumbs",
+    "name": "chris-ware/nova-breadcrumbs",
     "description": "A Laravel Nova tool.",
     "keywords": [
         "laravel",

--- a/src/Http/Controllers/NovaBreadcrumbsController.php
+++ b/src/Http/Controllers/NovaBreadcrumbsController.php
@@ -29,13 +29,7 @@ class NovaBreadcrumbsController extends Controller
         $novaHome = Str::finish($request->get('location')['origin'] . Nova::path(), '/');
         $path = Str::after($request->get('location')['href'], $novaHome);
         $pathParts = collect(explode('/', $path))->filter()->map(function ($part, $key) {
-            $itemParts = collect(explode('?', $part));
-
-            if ($itemParts->count() === 1) {
-                return $part;
-            }
-
-            return $itemParts->get(0);
+            return collect(explode('?', $part))->get(0);
         });
 
         $this->appendToCrumbs(__('Home'), '/');

--- a/src/Http/Controllers/NovaBreadcrumbsController.php
+++ b/src/Http/Controllers/NovaBreadcrumbsController.php
@@ -28,7 +28,16 @@ class NovaBreadcrumbsController extends Controller
         $view = str_replace('-', ' ', Str::after($request->get('view'), 'custom-'));
         $novaHome = Str::finish($request->get('location')['origin'] . Nova::path(), '/');
         $path = Str::after($request->get('location')['href'], $novaHome);
-        $pathParts = collect(explode('/', $path))->filter();
+        $pathParts = collect(explode('/', $path))->filter()->map(function ($part, $key) {
+            $itemParts = collect(explode('?', $part));
+
+            if ($itemParts->count() === 1) {
+                return $part;
+            }
+
+            return $itemParts->get(0);
+        });
+
         $this->appendToCrumbs(__('Home'), '/');
 
         if ($request->has('query')) {


### PR DESCRIPTION

This PR is intended to support another package [eminiarts/nova-tabs](https://github.com/eminiarts/nova-tabs).

When using [eminiarts/nova-tabs](https://github.com/eminiarts/nova-tabs), it will generate URL like

```
/resources/some-resource/some-id?tab=SomeTab
```

Currently, this package will grab the whole last path `some-id?tab=SomeTab`, so the model cannot find the appropriate id because string after question mark included in the last path.

This PR remove everything after the question mark `?`. Only `some-id` that will be returned. So the model can find the appropriate id.