### PR TITLE
fix broken fetch due to GET params

### DIFF
--- a/src/Http/Controllers/NovaBreadcrumbsController.php
+++ b/src/Http/Controllers/NovaBreadcrumbsController.php
@@ -68,7 +68,10 @@ class NovaBreadcrumbsController extends Controller
             $this->appendToCrumbs($lens, $pathParts->slice(0, 4)->implode('/'));
         } elseif ($pathParts->has(2)) {
             $this->resource = Nova::resourceForKey($pathParts->get(1));
-            $this->model = $this->findResourceOrFail($pathParts->get(2));
+
+            // we might have query params like '1003?tab=Company', so we clean it up.
+            $resourceId = Str::before($pathParts->get(2), '?');
+            $this->model = $this->findResourceOrFail($resourceId);
 
             $this->appendToCrumbs($this->model->breadcrumbResourceTitle(), $pathParts->slice(0, 3)->implode('/'));
         }


### PR DESCRIPTION
Finding a resource by ID failed currently for me due to:
```
SQLSTATE[22P02]: Invalid text representation: 7 ERROR:  invalid input syntax for type bigint: "1003?tab=Company" (SQL: select
```

being called in `NovaBreadcrumsController`:
```
$this->findResourceOrFail($pathParts->get(2))
```

but `$pathParts->get(2)` returned a string like "1003?tab=Company"

So this basically removes get params from the supposed to be resourceId.