### PR TITLE
Per-resource custom breadcrumb and minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ phpunit.xml
 .phpunit.result.cache
 .DS_Store
 Thumbs.db
+auth.json

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "laravel/nova": ">=3"
+        "laravel/nova": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Http/Controllers/NovaBreadcrumbsController.php
+++ b/src/Http/Controllers/NovaBreadcrumbsController.php
@@ -56,7 +56,7 @@ class NovaBreadcrumbsController extends Controller
                 }
                 $additionals = $this->model->customBreadcrumbs();
                 if (empty($additionals) == false) {
-                    foreach($additionals as $additional) {
+                    foreach ($additionals as $additional) {
                         if (empty($additional['label']) == false) {
                             $this->appendToCrumbs($additional['label'], $additional['url'] ?? '#');
                         }

--- a/src/Http/Controllers/NovaBreadcrumbsController.php
+++ b/src/Http/Controllers/NovaBreadcrumbsController.php
@@ -49,10 +49,24 @@ class NovaBreadcrumbsController extends Controller
 
             if (empty($this->resource) == false) {
                 $this->model = $this->findResourceOrFail($query->get('viaResourceId'));
-                $this->appendToCrumbs($this->resource::breadcrumbResourceLabel(),
-                    $cloneParts->slice(0, 2)->implode('/'));
-                $this->appendToCrumbs($this->model->breadcrumbResourceTitle(),
-                    $cloneParts->slice(0, 3)->implode('/'));
+                $resourceLabel = $this->resource::breadcrumbResourceLabel();
+                if (empty($resourceLabel) == false) {
+                    $this->appendToCrumbs($resourceLabel,
+                        $cloneParts->slice(0, 2)->implode('/'));
+                }
+                $additionals = $this->model->customBreadcrumbs();
+                if (empty($additionals) == false) {
+                    foreach($additionals as $additional) {
+                        if (empty($additional['label']) == false) {
+                            $this->appendToCrumbs($additional['label'], $additional['url'] ?? '#');
+                        }
+                    }
+                }
+                $resourceTitle = $this->model->breadcrumbResourceTitle();
+                if (empty($resourceTitle) == false) {
+                    $this->appendToCrumbs($this->model->breadcrumbResourceTitle(),
+                        $cloneParts->slice(0, 3)->implode('/'));
+                }
             }
         }
 
@@ -63,8 +77,11 @@ class NovaBreadcrumbsController extends Controller
         $this->resource = $this->resourceFromKey($pathParts->get(1));
 
         if ($this->resource) {
-            $this->appendToCrumbs($this->resource::breadcrumbResourceLabel(),
-                $pathParts->slice(0, 2)->implode('/'));
+            $resourceLabel = $this->resource::breadcrumbResourceLabel();
+            if (empty($resourceLabel) == false) {
+                $this->appendToCrumbs($this->resource::breadcrumbResourceLabel(),
+                    $pathParts->slice(0, 2)->implode('/'));
+            }
         }
 
         if ($view == 'create') {
@@ -77,9 +94,22 @@ class NovaBreadcrumbsController extends Controller
         } elseif ($pathParts->has(2)) {
             $this->resource = Nova::resourceForKey($pathParts->get(1));
             $this->model = $this->findResourceOrFail($pathParts->get(2));
+            if (method_exists($this->model, 'customBreadcrumbs')) {
+                $additionals = $this->model->customBreadcrumbs();
+                if (empty($additionals) == false) {
+                    foreach ($additionals as $additional) {
+                        if (empty($additional['label']) == false) {
+                            $this->appendToCrumbs($additional['label'], $additional['url'] ?? '#');
+                        }
+                    }
+                }
+            }
             if (method_exists($this->model, 'breadcrumbResourceTitle')) {
-                $this->appendToCrumbs($this->model->breadcrumbResourceTitle(),
-                    $pathParts->slice(0, 3)->implode('/'));
+                $resourceTitle = $this->model->breadcrumbResourceTitle();
+                if (empty($resourceTitle) == false) {
+                    $this->appendToCrumbs($this->model->breadcrumbResourceTitle(),
+                        $pathParts->slice(0, 3)->implode('/'));
+                }
             }
         }
 

--- a/src/Traits/Breadcrumbs.php
+++ b/src/Traits/Breadcrumbs.php
@@ -6,35 +6,37 @@ use Illuminate\Support\Collection;
 
 trait Breadcrumbs
 {
-    /**
-     * Prepare the resource for JSON serialization using the given fields.
-     *
-     * @param  \Illuminate\Support\Collection $fields
-     *
-     * @return array
-     */
-    protected function serializeWithId(Collection $fields)
-    {
-        $parent = parent::serializeWithId($fields);
-
-        return array_merge($parent, [
-            'label' => $this->breadcrumbResourceLabel(),
-            'title' => $this->breadcrumbResourceTitle(),
-        ]);
-    }
-
     public static function breadcrumbs()
     {
         return true;
     }
 
+    /**
+     * @return boolean|string The label of the resource to be shown in the breadcrumbs.
+     *                        If false, the resource will not be displayed
+     */
     public static function breadcrumbResourceLabel()
     {
         return static::label();
     }
 
+    /**
+     * @return boolean|string The title of the resource to be shown in the breadcrumbs.
+     *                        If false, the resource will not be displayed
+     */
     public function breadcrumbResourceTitle()
     {
         return $this->title();
     }
+
+    /**
+     * @return boolean|array Additional breadcrumbs to be shown. Should be defined as
+     *                       an array of ['label' => string, 'url' => string].
+     *                       If false, no additional items are going to be displayed
+     */
+    public function customBreadcrumbs()
+    {
+        return false;
+    }
+
 }

--- a/src/Traits/Breadcrumbs.php
+++ b/src/Traits/Breadcrumbs.php
@@ -2,8 +2,6 @@
 
 namespace ChrisWare\NovaBreadcrumbs\Traits;
 
-use Illuminate\Support\Collection;
-
 trait Breadcrumbs
 {
     public static function breadcrumbs()
@@ -12,8 +10,8 @@ trait Breadcrumbs
     }
 
     /**
-     * @return boolean|string The label of the resource to be shown in the breadcrumbs.
-     *                        If false, the resource will not be displayed
+     * @return bool|string The label of the resource to be shown in the breadcrumbs.
+     *                     If false, the resource will not be displayed
      */
     public static function breadcrumbResourceLabel()
     {
@@ -21,8 +19,8 @@ trait Breadcrumbs
     }
 
     /**
-     * @return boolean|string The title of the resource to be shown in the breadcrumbs.
-     *                        If false, the resource will not be displayed
+     * @return bool|string The title of the resource to be shown in the breadcrumbs.
+     *                     If false, the resource will not be displayed
      */
     public function breadcrumbResourceTitle()
     {
@@ -30,13 +28,12 @@ trait Breadcrumbs
     }
 
     /**
-     * @return boolean|array Additional breadcrumbs to be shown. Should be defined as
-     *                       an array of ['label' => string, 'url' => string].
-     *                       If false, no additional items are going to be displayed
+     * @return bool|array Additional breadcrumbs to be shown. Should be defined as
+     *                    an array of ['label' => string, 'url' => string].
+     *                    If false, no additional items are going to be displayed
      */
     public function customBreadcrumbs()
     {
         return false;
     }
-
 }


### PR DESCRIPTION
Hello,
I've changed some stuff in the package:

1. Now we have Nova 4, so I've changed the version to `^3.0` instead of `>=3`. This is because I don't think this library has been tested with Nova 4, and I think that it's better to show a compatibility issue between the dependencies from composer when upgrading to Nova 4, so that if someone has a license for Nova 4 can eventually change it to `^3.0|^4.0` after testing this package with the newer version of nova.
2. Added `auth.json` to gitignore, since it can be used for the license of nova if not configured globally
3. I've removed the `serializeWithId` method from the trait since it was not used anywhere
4. Added the possibility to remove the resource class link or resource instance link from the breadcrumb by returning false from `breadcrumbResourceLabel()` or `breadcrumbResourceTitle()` (potentially could solve #126 by adding some policy check on those methods and eventually returning false if the user is not allowed?)
5. Added the possibility to add custom breadcrumbs per-resource. To do so, one can simply override `customBreadcrumbs` and add some items. Those are visualized between the breadcrumbResourceLabel and the breadcrumbResourceTitle. In my case, I've used it to provide a breadcrumb showing the full hierarchy of models in a nested-set. 